### PR TITLE
Make function virtual in example and allow getApproved if caller is the locker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ As soon as I have a moment, I will add an example here and move the testing.
 
 Feel free to make a PR to add your contracts.
 
+## History
+
+**0.0.3**
+- `Lockable.getApproved` does not return address(0) if the token is locked but the caller is the locker. This allows the locker to stake the token transferring it.
+- Makes function in `Lockable` virtual to be overriden if necessary
+
 ## Copyright
 
 (c) 2022, Francesco Sullo <francesco@sullo.co>

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Feel free to make a PR to add your contracts.
 
 **0.0.3**
 - `Lockable.getApproved` does not return address(0) if the token is locked but the caller is the locker. This allows the locker to stake the token transferring it.
-- Makes function in `Lockable` virtual to be overriden if necessary
+- Makes function in `Lockable` virtual to be overridden if necessary
 
 ## Copyright
 

--- a/contracts/ILockable.sol
+++ b/contracts/ILockable.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.4;
 
 // ERC165 interface id is 0xd8e4c296
 interface ILockable {
-
   event LockerSet(address locker);
   event LockerRemoved(address locker);
   event ForcefullyUnlocked(uint256 tokenId);

--- a/contracts/LockableUpgradeable.sol
+++ b/contracts/LockableUpgradeable.sol
@@ -12,7 +12,14 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import "./ILockable.sol";
 
-contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ERC721Upgradeable, ERC721EnumerableUpgradeable, UUPSUpgradeable {
+contract LockableUpgradeable is
+  ILockable,
+  Initializable,
+  OwnableUpgradeable,
+  ERC721Upgradeable,
+  ERC721EnumerableUpgradeable,
+  UUPSUpgradeable
+{
   using AddressUpgradeable for address;
 
   mapping(address => bool) private _locker;
@@ -31,7 +38,7 @@ contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ER
     __Ownable_init();
   }
 
-  function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+  function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
 
   function _beforeTokenTransfer(
     address from,
@@ -51,32 +58,31 @@ contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ER
     return interfaceId == type(ILockable).interfaceId || super.supportsInterface(interfaceId);
   }
 
-
-  function isLocked(uint256 tokenId) public view override returns (bool) {
+  function isLocked(uint256 tokenId) public view virtual override returns (bool) {
     return _lockedBy[tokenId] != address(0);
   }
 
-  function lockerOf(uint256 tokenId) external view override returns (address) {
+  function lockerOf(uint256 tokenId) public view virtual override returns (address) {
     return _lockedBy[tokenId];
   }
 
-  function isLocker(address locker) public view override returns (bool) {
+  function isLocker(address locker) public view virtual override returns (bool) {
     return _locker[locker];
   }
 
-  function setLocker(address locker) external override onlyOwner {
+  function setLocker(address locker) external virtual override onlyOwner {
     require(locker.isContract(), "Locker not a contract");
     _locker[locker] = true;
     emit LockerSet(locker);
   }
 
-  function removeLocker(address locker) external override onlyOwner {
+  function removeLocker(address locker) external virtual override onlyOwner {
     require(_locker[locker], "Not an active locker");
     delete _locker[locker];
     emit LockerRemoved(locker);
   }
 
-  function hasLocks(address owner) public view override returns (bool) {
+  function hasLocks(address owner) public view virtual override returns (bool) {
     uint256 balance = balanceOf(owner);
     for (uint256 i = 0; i < balance; i++) {
       uint256 id = tokenOfOwnerByIndex(owner, i);
@@ -87,7 +93,7 @@ contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ER
     return false;
   }
 
-  function lock(uint256 tokenId) external override onlyLocker {
+  function lock(uint256 tokenId) external virtual override onlyLocker {
     // locker must be approved to mark the token as locked
     require(isLocker(_msgSender()), "Not an authorized locker");
     require(getApproved(tokenId) == _msgSender() || isApprovedForAll(ownerOf(tokenId), _msgSender()), "Locker not approved");
@@ -95,7 +101,7 @@ contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ER
     emit Locked(tokenId);
   }
 
-  function unlock(uint256 tokenId) external override onlyLocker {
+  function unlock(uint256 tokenId) external virtual override onlyLocker {
     // will revert if token does not exist
     require(_lockedBy[tokenId] == _msgSender(), "Wrong locker");
     delete _lockedBy[tokenId];
@@ -103,7 +109,7 @@ contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ER
   }
 
   // emergency function in case a compromised locker is removed
-  function unlockIfRemovedLocker(uint256 tokenId) external override onlyOwner {
+  function unlockIfRemovedLocker(uint256 tokenId) external virtual override onlyOwner {
     require(isLocked(tokenId), "Not a locked tokenId");
     require(!_locker[_lockedBy[tokenId]], "Locker is still active");
     delete _lockedBy[tokenId];
@@ -112,28 +118,27 @@ contract LockableUpgradeable is ILockable, Initializable, OwnableUpgradeable, ER
 
   // manage approval
 
-  function approve(address to, uint256 tokenId) public override {
+  function approve(address to, uint256 tokenId) public virtual override {
     require(!isLocked(tokenId), "Locked asset");
     super.approve(to, tokenId);
   }
 
-  function getApproved(uint256 tokenId) public view override returns (address) {
-    if (isLocked(tokenId)) {
+  function getApproved(uint256 tokenId) public view virtual override returns (address) {
+    if (isLocked(tokenId) && lockerOf(tokenId) != _msgSender()) {
       return address(0);
     }
     return super.getApproved(tokenId);
   }
 
-  function setApprovalForAll(address operator, bool approved) public override {
+  function setApprovalForAll(address operator, bool approved) public virtual override {
     require(!approved || !hasLocks(_msgSender()), "At least one asset is locked");
     super.setApprovalForAll(operator, approved);
   }
 
-  function isApprovedForAll(address owner, address operator) public view override returns (bool) {
+  function isApprovedForAll(address owner, address operator) public view virtual override returns (bool) {
     if (hasLocks(owner)) {
       return false;
     }
     return super.isApprovedForAll(owner, operator);
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/lockable",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
1. In the implementation, now functions are virtual, so they can be overridden.

2. Also,  the function `getApproved` does not return address(0) if the caller is the locker of the token. This allows the player to actually stake the token transferring it, if needed. Thanks to point 1, it can be overridden if needed.
