### PR TITLE
Using an init function instead of initialize to make it easier to extend

### DIFF
--- a/contracts/LockableUpgradeable.sol
+++ b/contracts/LockableUpgradeable.sol
@@ -30,11 +30,15 @@ contract LockableUpgradeable is
     _;
   }
 
-  /// @custom:oz-upgrades-unsafe-allow constructor
-  constructor() initializer {}
+  /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+  function __Lockable_init(string memory name_, string memory symbol_) internal onlyInitializing {
+    __Lockable_init_unchained(name_, symbol_);
+  }
 
-  function initialize(string memory name, string memory symbol) public initializer {
-    __ERC721_init(name, symbol);
+  function __Lockable_init_unchained(string memory name_, string memory symbol_) internal onlyInitializing {
+    __ERC721_init(name_, symbol_);
     __Ownable_init();
   }
 
@@ -141,4 +145,6 @@ contract LockableUpgradeable is
     }
     return super.isApprovedForAll(owner, operator);
   }
+
+  uint256[50] private __gap;
 }

--- a/contracts/mocks/LockableUpgradeableMock.sol
+++ b/contracts/mocks/LockableUpgradeableMock.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.11;
+
+// Authors: Francesco Sullo <francesco@sullo.co>
+
+import "../LockableUpgradeable.sol";
+
+//import "hardhat/console.sol";
+
+contract LockableUpgradeableMock is LockableUpgradeable {
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() initializer {}
+
+  function initialize(string memory name, string memory symbol) public initializer {
+    __Lockable_init(name, symbol);
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/lockable",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"

--- a/test/Lockable.test.js
+++ b/test/Lockable.test.js
@@ -14,7 +14,7 @@ describe("Lockable", function () {
 
   beforeEach(async function () {
     // myPool = await deployContract("MyPlayer");
-    myToken = await deployContractUpgradeable("LockableUpgradeable", ["My token", "NFT"]);
+    myToken = await deployContractUpgradeable("LockableUpgradeableMock", ["My token", "NFT"]);
   });
 
   it("should verify the flow", async function () {


### PR DESCRIPTION
- [x] remove `initialize` (which was used in the example) and use `__Lockable_init` to allow extensions
- [x] add `__gap` at the end
- [x] add mock to allow testing